### PR TITLE
Document GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# rebuttal-page-template
+# Rebuttal Page Template
+
+This repository contains a single-page workspace tailored for paper rebuttals. It
+provides live Markdown previews, KaTeX math rendering, syntax-highlighted code
+listings, and organized reviewer response lanes so you can stay coordinated
+through the rebuttal window.
+
+## Features
+
+- **Reviewer threads** &mdash; Dedicated cards to draft and iterate on answers for
+  each reviewer, complete with Markdown editors and live previews plus follow-up
+  conversation logs per reviewer.
+- **Math typesetting** &mdash; Write inline or display math (including `\mathbb` and
+  macros such as `\RR`) using KaTeX through the `markdown-it-texmath` plugin.
+- **Tables and listings** &mdash; Render Markdown and LaTeX-style tables plus
+  syntax-highlighted code blocks via Highlight.js.
+- **Quick copy** &mdash; Export any response with a single click using the copy
+  buttons in each reviewer card.
+- **Discussion log** &mdash; Capture clarifications or internal decisions in a
+  separate notes panel.
+
+## Getting started
+
+1. Clone or download this repository.
+2. Open `index.html` in your browser. No build step is required.
+3. Edit the Markdown in each panel; the preview updates instantly.
+
+> Tip: Use the "Copy Markdown" button on any card to paste the prepared answer
+> directly into OpenReview or your submission portal.
+
+## Deploying on GitHub Pages
+
+The project is a plain static site, so it can be published on GitHub Pages with
+no additional tooling:
+
+1. Commit the contents of this repository to your `main` (or `master`) branch.
+2. In your GitHub project, navigate to **Settings → Pages**.
+3. Under **Build and deployment**, choose **Deploy from a branch**, select your
+   default branch, and set the folder to `/ (root)`.
+4. Save the configuration—Pages will build the site automatically and serve it
+   at `https://<username>.github.io/<repo>/` within a couple of minutes.
+
+Because the template uses relative paths for local assets (`styles.css` and
+`script.js`) and loads all libraries from public CDNs over HTTPS, no further
+configuration is required for GitHub Pages.
+
+## Customization
+
+- Duplicate reviewer cards in `index.html` to track additional discussions.
+- Update the placeholder Markdown to match your paper details and reviewer
+  comments.
+- Adjust the appearance in `styles.css` if you prefer a different theme.
+
+## Acknowledgements
+
+This template uses the following open-source libraries via CDN:
+
+- [markdown-it](https://github.com/markdown-it/markdown-it) with the footnote and
+  texmath plugins
+- [KaTeX](https://katex.org/) for math rendering
+- [Highlight.js](https://highlightjs.org/) for syntax highlighting

--- a/index.html
+++ b/index.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rebuttal Workspace</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
+      integrity="sha384-cPwlPLvBTa2H7LZ8WZ2GJE0E7E0WJl7lX2WpFL3j+qDMvjxH92wFMsp7E/7dZ5FP"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="container">
+        <h1>Rebuttal Workspace</h1>
+        <p class="lead">
+          Organize responses, clarify experiments, and collaborate with co-authors
+          during the rebuttal window.
+        </p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="overview">
+        <article class="card">
+          <h2>Project Overview</h2>
+          <div id="overview-preview" class="markdown-preview"></div>
+          <textarea
+            id="overview-editor"
+            class="markdown-editor"
+            aria-label="Overview markdown editor"
+          ># Paper Snapshot
+
+- **Title**: Efficient Multimodal Transformers for Structured Reasoning
+- **ID**: Paper #137
+- **Deadline**: Feb 15, 23:59 PST
+- **Task Force**: Alice, Bob, Chen
+
+> Keep this section up to date with key facts and a succinct summary.
+
+## Key Links
+
+| Resource | URL |
+| --- | --- |
+| Paper PDF | [arXiv 2410.12345](https://arxiv.org/abs/2410.12345) |
+| Code Repo | [github.com/example/reasoning-transformer](https://github.com/example/reasoning-transformer) |
+| Dataset | Internal S3 bucket |
+
+### Highlight
+
+- Additional ablations ready to upload
+- Reviewer 2 concerned with scaling law extrapolation
+- Reviewer 3 asked for stronger baselines
+</textarea>
+        </article>
+      </section>
+
+      <section class="workspace">
+        <h2 class="section-title">Reviewer Threads</h2>
+        <div class="grid">
+          <article class="card" data-reviewer="Reviewer 1">
+            <header class="card-header">
+              <div>
+                <h3>Reviewer 1 &mdash; Clarity</h3>
+                <p class="meta">Focus: Method explanation, notation consistency</p>
+              </div>
+              <button class="copy-button" type="button" aria-label="Copy reviewer 1 response">
+                Copy Markdown
+              </button>
+            </header>
+            <div class="thread-block">
+              <div class="markdown-preview"></div>
+              <textarea class="markdown-editor" aria-label="Reviewer 1 markdown editor">
+## Planned Response
+
+Thank you for highlighting the missing intuition behind Equation (4). To clarify:
+
+1. We extend the factorized attention mechanism from Eq. (2) by allowing modality-specific temperatures \(\tau_m\).
+2. The feature projection matrices \(W_m\) remain shared, so the update does not increase parameter count.
+
+```python
+# Listing used in the supplement
+with torch.autocast("cuda"):
+    logits = fusion(query, keys, values, temperature=per_modality_tau)
+```
+
+### Next Steps
+
+- [x] Produce a small visualization of attention maps.
+- [ ] Add the explanation to Section 3.2 and upload to OpenReview.
+</textarea>
+            </div>
+            <div class="thread-block thread-followup">
+              <div class="thread-followup-header">
+                <h4>Ongoing Conversation</h4>
+                <p class="hint">Log clarifications, synchronous chat notes, or reviewer back-and-forth.</p>
+              </div>
+              <div class="markdown-preview"></div>
+              <textarea
+                class="markdown-editor"
+                aria-label="Reviewer 1 ongoing conversation editor"
+              >### Conversation Log
+
+- *2025-02-02*: Reviewer asked whether the intuition section will include gradient flow comments.
+- *Next step*: Draft 2-sentence clarification for Appendix B.
+</textarea>
+            </div>
+          </article>
+
+          <article class="card" data-reviewer="Reviewer 2">
+            <header class="card-header">
+              <div>
+                <h3>Reviewer 2 &mdash; Experimental Rigor</h3>
+                <p class="meta">Focus: Scaling laws, compute budget, baselines</p>
+              </div>
+              <button class="copy-button" type="button" aria-label="Copy reviewer 2 response">
+                Copy Markdown
+              </button>
+            </header>
+            <div class="thread-block">
+              <div class="markdown-preview"></div>
+              <textarea class="markdown-editor" aria-label="Reviewer 2 markdown editor">
+## Scaling Law Clarification
+
+We re-fitted the scaling law using the expanded dataset (n=12) and obtained:
+
+$$
+\mathcal{L}(C) = 0.21 C^{-0.37} + 0.48
+$$
+
+The coefficient of determination improved from 0.61 to 0.84.
+
+| Compute (PF-days) | Validation Error |
+| ---: | ---: |
+| 0.5 | 0.92 |
+| 1.0 | 0.71 |
+| 2.0 | 0.58 |
+| 4.0 | 0.52 |
+
+### Checklist
+
+- [x] Attach updated ablation table in the supplement
+- [ ] Provide clarification on hyperparameter sweep budget
+- [ ] Double-check \(\mathbb{E}[L]\) notation consistency
+</textarea>
+            </div>
+            <div class="thread-block thread-followup">
+              <div class="thread-followup-header">
+                <h4>Ongoing Conversation</h4>
+                <p class="hint">Track reviewer replies, side calculations, or meeting notes.</p>
+              </div>
+              <div class="markdown-preview"></div>
+              <textarea
+                class="markdown-editor"
+                aria-label="Reviewer 2 ongoing conversation editor"
+              >### Conversation Log
+
+- *Pending*: Reviewer awaiting clarification on compute ceiling for sweep.
+- *Action*: Prepare small table comparing GPU hours for each configuration.
+</textarea>
+            </div>
+          </article>
+
+          <article class="card" data-reviewer="Reviewer 3">
+            <header class="card-header">
+              <div>
+                <h3>Reviewer 3 &mdash; Baselines</h3>
+                <p class="meta">Focus: Additional comparisons, reproducibility</p>
+              </div>
+              <button class="copy-button" type="button" aria-label="Copy reviewer 3 response">
+                Copy Markdown
+              </button>
+            </header>
+            <div class="thread-block">
+              <div class="markdown-preview"></div>
+              <textarea class="markdown-editor" aria-label="Reviewer 3 markdown editor">
+## Addressing Baseline Concerns
+
+Thank you for pointing out the missing contrastive baseline. We have now included **Co-BERT** and **Unified-CLIP**. The updated Table 6 in the supplement shows our method outperforming both by 2.1% and 3.4% absolute accuracy, respectively.
+
+> We will release the training script with deterministic seeding to ensure reproducibility.
+
+#### Pending Items
+
+1. Upload the extended results table.
+2. Provide learning rate sweep details.
+3. Summarize compute for new baselines in Appendix D.
+</textarea>
+            </div>
+            <div class="thread-block thread-followup">
+              <div class="thread-followup-header">
+                <h4>Ongoing Conversation</h4>
+                <p class="hint">Use this to coordinate longer-term follow-ups or external inquiries.</p>
+              </div>
+              <div class="markdown-preview"></div>
+              <textarea
+                class="markdown-editor"
+                aria-label="Reviewer 3 ongoing conversation editor"
+              >### Conversation Log
+
+- *Idea*: Offer reproducibility checklist with seeds and configs as supplementary.
+- *Reminder*: Confirm whether reviewer wants per-class metrics breakdown.
+</textarea>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="discussion">
+        <h2 class="section-title">Discussion Notes</h2>
+        <div class="card">
+          <div class="markdown-preview"></div>
+          <textarea class="markdown-editor" aria-label="Discussion markdown editor">
+### Internal Discussion Log
+
+- Coordinate with **Chen** to finish the synthetic data ablation.
+- Schedule a rehearsal for the 1-minute summary video.
+
+> Use this panel to capture quick clarifications or discussion items during the rebuttal sprint.
+</textarea>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <div class="container">
+        <p>
+          Built with ❤️ for fast-paced rebuttal workflows. Export sections as Markdown
+          or copy responses directly into OpenReview.
+        </p>
+      </div>
+    </footer>
+
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/markdown-it@13.0.1/dist/markdown-it.min.js"
+      integrity="sha384-25mWlHxA1cKH5yGPZq3R1qcrIHbuU9MGsPw2ouPcAm6JGZveHFkNjEcNWef39QhH"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/markdown-it-footnote@3.0.3/dist/markdown-it-footnote.min.js"
+      integrity="sha384-NpdglYXTRhMibqL5d3NYkWSItNoBHSncGf3i0/yUuHF/D4hgI+tx6GWPOgk6WQwP"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js"
+    ></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
+      integrity="sha384-jMEfhmGkYr7qs9kaffaYzVDHfRauBRJXf7UL+jvtnYFeNap8+JvLZqLMq2LFhX1g"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/markdown-it-texmath@1.0.0/texmath.min.js"
+    ></script>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,83 @@
+(() => {
+  const init = () => {
+    if (typeof window.markdownit === "undefined") {
+      console.error("Markdown-it failed to load");
+      return;
+    }
+
+    const md = window
+      .markdownit({
+        html: false,
+        linkify: true,
+        typographer: true,
+        highlight(str, lang) {
+          if (lang && window.hljs && window.hljs.getLanguage(lang)) {
+            try {
+              return window.hljs.highlight(str, { language: lang }).value;
+            } catch (err) {
+              console.warn("Highlight error", err);
+            }
+          }
+          return md.utils.escapeHtml(str);
+        },
+      })
+      .use(window.markdownitFootnote || (() => {}));
+
+    if (window.texmath && window.katex) {
+      const tm = window.texmath.use(window.katex);
+      md.use(tm, {
+        delimiters: "dollars",
+        katexOptions: {
+          macros: {
+            "\\RR": "\\mathbb{R}",
+            "\\CC": "\\mathbb{C}",
+          },
+        },
+      });
+    }
+
+    const editors = Array.from(document.querySelectorAll(".markdown-editor"));
+    const previews = Array.from(document.querySelectorAll(
+      ".markdown-preview"
+    ));
+
+    const renderPreview = (textarea, preview) => {
+      if (!preview) return;
+      const rendered = md.render(textarea.value);
+      preview.innerHTML = rendered;
+    };
+
+    editors.forEach((textarea, index) => {
+      const preview = previews[index];
+      renderPreview(textarea, preview);
+
+      textarea.addEventListener("input", () => {
+        renderPreview(textarea, preview);
+      });
+    });
+
+    // Copy to clipboard buttons
+    document.querySelectorAll(".card").forEach((card) => {
+      const button = card.querySelector(".copy-button");
+      const textarea = card.querySelector(".markdown-editor");
+      if (!button || !textarea) return;
+
+      button.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(textarea.value);
+          button.classList.add("copied");
+          setTimeout(() => button.classList.remove("copied"), 2000);
+        } catch (error) {
+          console.error("Clipboard copy failed", error);
+          button.textContent = "Copy failed";
+        }
+      });
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,301 @@
+:root {
+  color-scheme: light;
+  --background: #f7f7fb;
+  --card-background: #ffffff;
+  --accent: #3b82f6;
+  --accent-soft: rgba(59, 130, 246, 0.1);
+  --text-primary: #1f2933;
+  --text-secondary: #52606d;
+  --border: #d9e2ec;
+  --shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: var(--background);
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.container {
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+}
+
+.app-header {
+  background: var(--card-background);
+  border-bottom: 1px solid var(--border);
+  padding: 3.5rem 0 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(8px);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 2.8rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.lead {
+  margin: 0.5rem 0 0;
+  max-width: 640px;
+  color: var(--text-secondary);
+}
+
+main.container {
+  padding: 2rem 0 4rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.section-title {
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+}
+
+.card {
+  background: var(--card-background);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(209, 213, 219, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.card-header h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.35rem;
+}
+
+.meta {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.thread-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.thread-followup {
+  border-top: 1px solid var(--border);
+  padding-top: 1.25rem;
+  margin-top: 0.5rem;
+}
+
+.thread-followup-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.thread-followup-header h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.hint {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+}
+
+.markdown-editor {
+  width: 100%;
+  min-height: 160px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--accent-soft);
+  padding: 1rem 1.1rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono",
+    Menlo, monospace;
+  font-size: 0.95rem;
+  resize: vertical;
+  color: var(--text-primary);
+}
+
+.markdown-preview {
+  border-radius: 14px;
+  border: 1px dashed rgba(148, 163, 184, 0.5);
+  padding: 1rem 1.25rem;
+  background: #fbfcff;
+  min-height: 140px;
+}
+
+.markdown-preview table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+}
+
+.markdown-preview th,
+.markdown-preview td {
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.markdown-preview thead {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.markdown-preview code {
+  background: rgba(15, 23, 42, 0.05);
+  padding: 0.15rem 0.3rem;
+  border-radius: 6px;
+  font-size: 0.92em;
+}
+
+.markdown-preview pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+.markdown-preview pre {
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 12px;
+  padding: 1rem;
+  overflow-x: auto;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3);
+}
+
+.copy-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 10px 20px rgba(59, 130, 246, 0.25);
+}
+
+.copy-button:hover,
+.copy-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(59, 130, 246, 0.3);
+}
+
+.copy-button:active {
+  transform: translateY(0);
+  box-shadow: 0 6px 14px rgba(59, 130, 246, 0.25);
+}
+
+.copy-button.copied {
+  background: #059669;
+  box-shadow: 0 10px 20px rgba(5, 150, 105, 0.3);
+}
+
+.copy-button.copied::after {
+  content: "Copied!";
+  margin-left: 0.5rem;
+}
+
+.app-footer {
+  padding: 2.5rem 0 3rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.markdown-preview blockquote {
+  border-left: 4px solid var(--accent);
+  margin: 1rem 0;
+  padding-left: 1rem;
+  color: var(--text-secondary);
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 0 12px 12px 0;
+}
+
+.markdown-preview ul,
+.markdown-preview ol {
+  padding-left: 1.25rem;
+}
+
+.markdown-preview h1,
+.markdown-preview h2,
+.markdown-preview h3,
+.markdown-preview h4 {
+  margin: 1.5rem 0 0.75rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.markdown-preview h1 {
+  font-size: 1.8rem;
+}
+
+.markdown-preview h2 {
+  font-size: 1.45rem;
+}
+
+.markdown-preview h3 {
+  font-size: 1.2rem;
+}
+
+.markdown-preview h4 {
+  font-size: 1.05rem;
+}
+
+.markdown-preview p {
+  margin: 0.75rem 0;
+}
+
+.markdown-preview sup {
+  font-size: 0.75em;
+}
+
+.app-footer p {
+  margin: 0;
+  text-align: center;
+}
+
+textarea:focus {
+  outline: 2px solid rgba(59, 130, 246, 0.4);
+  outline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .card {
+    padding: 1.25rem;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .copy-button {
+    align-self: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- document the steps required to publish the static rebuttal workspace via GitHub Pages
- clarify that relative asset paths and CDN-hosted libraries make the template ready for immediate deployment

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e51b95da788329b4558cb658f5317c